### PR TITLE
feat: 增加聊天消息助手样式右边距

### DIFF
--- a/SharpPad/wwwroot/styles/base.css
+++ b/SharpPad/wwwroot/styles/base.css
@@ -193,6 +193,7 @@ body.theme-light .chat-messages .assistant-message {
     cursor: pointer;
     font-size: 14px;
     transition: background-color 0.2s;
+    margin-right: 6rem;
 }
 
 #runButton:hover, #themeButton:hover {


### PR DESCRIPTION
- 在 base.css 中为助手消息添加右边距 6rem，以改善布局和可读性