### PR TITLE
Run Roslyn code in isolated process

### DIFF
--- a/SharpPad/Controllers/CodeRunController.cs
+++ b/SharpPad/Controllers/CodeRunController.cs
@@ -204,11 +204,19 @@ namespace SharpPad.Controllers
 
             try
             {
+                var processStopped = CodeRunner.TryStopProcess(request.SessionId);
+
                 // 查找并取消对应的会话，使用线程安全操作
+                var sessionStopped = false;
                 if (_activeSessions.TryRemove(request.SessionId, out var cts))
                 {
                     cts?.Cancel();
                     cts?.Dispose();
+                    sessionStopped = true;
+                }
+
+                if (processStopped || sessionStopped)
+                {
                     return Ok(new { success = true, message = "代码执行已停止" });
                 }
 

--- a/SharpPad/Controllers/CodeRunController.cs
+++ b/SharpPad/Controllers/CodeRunController.cs
@@ -57,7 +57,7 @@ namespace SharpPad.Controllers
                     result = await CodeRunner.RunMultiFileCodeAsync(
                         request.Files,
                         nugetPackages,
-                        request?.LanguageVersion ?? 2147483647,
+                        request?.LanguageVersion ?? DEFAULT_LANGUAGE_VERSION,
                         message => OnOutputAsync(message, channel.Writer, cts.Token),
                         error => OnErrorAsync(error, channel.Writer, cts.Token),
                         sessionId: request?.SessionId,
@@ -71,7 +71,7 @@ namespace SharpPad.Controllers
                     result = await CodeRunner.RunProgramCodeAsync(
                         request?.SourceCode,
                         nugetPackages,
-                        request?.LanguageVersion ?? 2147483647,
+                        request?.LanguageVersion ?? DEFAULT_LANGUAGE_VERSION,
                         message => OnOutputAsync(message, channel.Writer, cts.Token),
                         error => OnErrorAsync(error, channel.Writer, cts.Token),
                         sessionId: request?.SessionId,
@@ -242,7 +242,7 @@ namespace SharpPad.Controllers
                     result = await CodeRunner.BuildMultiFileExecutableAsync(
                         request.Files,
                         nugetPackages,
-                        request?.LanguageVersion ?? 2147483647,
+                        request?.LanguageVersion ?? DEFAULT_LANGUAGE_VERSION,
                         request?.OutputFileName ?? "Program.exe",
                         request?.ProjectType
                     );
@@ -252,7 +252,7 @@ namespace SharpPad.Controllers
                     result = await CodeRunner.BuildExecutableAsync(
                         request?.SourceCode,
                         nugetPackages,
-                        request?.LanguageVersion ?? 2147483647,
+                        request?.LanguageVersion ?? DEFAULT_LANGUAGE_VERSION,
                         request?.OutputFileName ?? "Program.exe",
                         request?.ProjectType
                     );


### PR DESCRIPTION
## Summary
- execute user code in an isolated `dotnet run` process with streamed output/input handling
- add process tracking helpers so the stop API cancels both the token and the external process

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d80e3d412083339ff0298712cf1cc3