### PR TITLE
Add Avalonia project type support and default packages

### DIFF
--- a/SharpPad/wwwroot/execution/runner.js
+++ b/SharpPad/wwwroot/execution/runner.js
@@ -294,6 +294,8 @@ export class CodeRunner {
         switch ((projectType || '').toLowerCase()) {
             case 'winforms':
                 return 'WinForms 桌面';
+            case 'avalonia':
+                return 'Avalonia 桌面';
             case 'webapi':
                 return 'ASP.NET Core Web API';
             default:

--- a/SharpPad/wwwroot/fileSystem/fileManager.js
+++ b/SharpPad/wwwroot/fileSystem/fileManager.js
@@ -68,7 +68,7 @@ class FileManager {
             return allowed[0] || fallback;
         }
 
-        const allowedFallback = ['console', 'winforms', 'webapi'];
+        const allowedFallback = ['console', 'winforms', 'avalonia', 'webapi'];
         if (candidate && allowedFallback.includes(candidate)) {
             return candidate;
         }

--- a/SharpPad/wwwroot/index.html
+++ b/SharpPad/wwwroot/index.html
@@ -69,6 +69,7 @@
                 <select id="projectTypeSelect" class="version-select project-type-select" title="选择项目类型">
                     <option value="console">Console</option>
                     <option value="winforms">WinForms</option>
+                    <option value="avalonia">Avalonia</option>
                     <option value="webapi">Web API</option>
                 </select>
             </div>


### PR DESCRIPTION
## Summary
- add Avalonia project type detection to the runtime, default package provisioning, and safer package downloads
- merge default packages server-side for completion/run/build requests and expose a helper for controllers
- surface the Avalonia option in the UI project type selector and update labels/normalization

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build SharpPad.sln` *(fails: unable to reach NuGet feeds through proxy, build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68f5dfcc9c488333bd68dcc3894152c6